### PR TITLE
increase number of receivers supported by Red Pitaya

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Hermes Lite:
 - 8 receivers with BeMicro CV A9 and N1GP firmware
 
 Red Pitaya
-- 6 receivers with http://pavel-demin.github.io/red-pitaya-notes/sdr-receiver-hpsdr/
+- 8 receivers with http://pavel-demin.github.io/red-pitaya-notes/sdr-receiver-hpsdr/
 
 Angelia:
 - 7 receivers

--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,7 @@ Hermes Lite:
 - 8 receivers with BeMicro CV A9 and N1GP firmware
 
 Red Pitaya
-- 6 receivers with http://pavel-demin.github.io/red-pitaya-notes/sdr-receiver-hpsdr/
+- 8 receivers with http://pavel-demin.github.io/red-pitaya-notes/sdr-receiver-hpsdr/
 
 Angelia:
 - 7 receivers


### PR DESCRIPTION
Red Pitaya can now send up-to eight I/Q streams to CW Skimmer Server. I've updated the readme files accordingly.