### PR TITLE
Send a separate Discovery packet for P2 since some clients are lookin…

### DIFF
--- a/HermesIntf/Hermes.cpp
+++ b/HermesIntf/Hermes.cpp
@@ -329,11 +329,12 @@ namespace HermesIntf
 		char recvbuff[1500] = {0};
 		int recvbufflen = 1500;
 		char sendMSG[63] = {0};
+		char sendMSG_P2[60] = {0};
 		sendMSG[0] = (char) 0xEF;
 		sendMSG[1] = (char) 0xFE;
 		sendMSG[2] = (char) 0x02;
 
-		sendMSG[4] = (char) 0x02;
+		sendMSG_P2[4] = (char) 0x02;
 
 		//send out broadcast from each interface
 		
@@ -370,9 +371,11 @@ namespace HermesIntf
 			//calculate magic broadcast address
 			bcast_addr.sin_addr.S_un.S_addr = pAddress->sin_addr.S_un.S_addr | (~ pMask->sin_addr.S_un.S_addr);
 
-			//send discovery
+			//send discovery P1
 			sendto(sock,sendMSG,sizeof(sendMSG),0,(sockaddr *)&bcast_addr,sizeof(bcast_addr));
 
+			//send discovery P2
+			sendto(sock, sendMSG_P2, sizeof(sendMSG_P2), 0, (sockaddr*)& bcast_addr, sizeof(bcast_addr));
 		}
 
 		


### PR DESCRIPTION
…g for a 60 byte packet.

Hi Vasiliy, I am helping to work on a new ANAN board that uses a Xilinx FPGA and a
CM4 Raspberry PI module. The main developer has implemented the Protocol 2 in a
way that strictly looks for a discovery packet of 60 bytes. This is actually what is in the
protocol documentation. Other Hermes/Orion boards are not strictly looking at packet
size and work fine with the 63 bytes.

I have tested this not only on the new ANAN board (Saturn) but also on other Hermes both
P1 and P2.

BTW, Thetis also sends both a P1 and P2 discovery packet.