### PR TITLE
Adding support for Metis/Mercury firmware that supports 8 Rx's, firmw…

### DIFF
--- a/HermesIntf/Hermes.cpp
+++ b/HermesIntf/Hermes.cpp
@@ -454,7 +454,7 @@ namespace HermesIntf
 					{
 					case 0x00:
 						devname = (char *) METIS;
-						max_recvrs = 4;
+						max_recvrs = (ver < 10) ? 8 : 6;
 						Att = 0;
 						MaxAtt = 0;
 						break;

--- a/HermesIntf/HermesIntf.cpp
+++ b/HermesIntf/HermesIntf.cpp
@@ -685,7 +685,7 @@ namespace HermesIntf
 				rt_exception("HPSDR is busy sending data");
 				return;
 			} else if ((myHermes.devname == HERMES && (myHermes.ver != 18 && myHermes.ver < 24)) 
-				|| (myHermes.devname == METIS && myHermes.ver < 26) 
+				|| (myHermes.devname == METIS && (myHermes.ver > 10 && myHermes.ver < 30))
 				|| (myHermes.devname == ANGELIA && myHermes.ver < 19)) 
 			{
 				rt_exception("Check FPGA firmware version");


### PR DESCRIPTION
…are versions will be between 1 and 9 since they were never used.

I pulled my Atlas system off the shelf and gave it something to do.
I added GigE and the HL2 NCO (instead of Cordic) plus only using
CIC filters.

Seems pretty good for skimming.